### PR TITLE
Fix Cassandra connection and add multi-spaces testing tab

### DIFF
--- a/infrastructure/adapters/in_/ui/streamlit_app.py
+++ b/infrastructure/adapters/in_/ui/streamlit_app.py
@@ -16,6 +16,7 @@ from infrastructure.adapters.in_.ui.views.maintainers_view import maintainers_ta
 from infrastructure.adapters.in_.ui.views.performance_view import performance_test_view
 from infrastructure.adapters.in_.ui.views.results_view import results_tab_view
 from infrastructure.adapters.in_.ui.views.billing_view import billing_tab_view
+from infrastructure.adapters.in_.ui.views.multi_spaces_view import multi_spaces_tab_view
 
 st.set_page_config(page_title="Comparación de Bases de Datos", layout="wide")
 
@@ -160,9 +161,10 @@ def run_app():
         st.error("Los servicios de aplicación no se inicializaron correctamente. Intente reconectar.")
         return
 
-    tab_mantenedores, tab_pruebas, tab_resultados, tab_facturacion = st.tabs([
+    tab_mantenedores, tab_pruebas, tab_multi, tab_resultados, tab_facturacion = st.tabs([
         "Mantenedores",
         "Ejecutar Pruebas de Rendimiento",
+        "Multi-Spaces",
         "Resultados y Estadísticas",
         "Proceso de Facturación"
     ])
@@ -172,6 +174,9 @@ def run_app():
 
     with tab_pruebas:
         performance_test_view(st.session_state.performance_service, st.session_state.db_type_selected)
+
+    with tab_multi:
+        multi_spaces_tab_view(DB_DEFAULTS)
 
     with tab_resultados:
         results_tab_view(st.session_state.performance_service)

--- a/infrastructure/adapters/in_/ui/views/multi_spaces_view.py
+++ b/infrastructure/adapters/in_/ui/views/multi_spaces_view.py
@@ -1,0 +1,67 @@
+import streamlit as st
+from infrastructure.adapters.out.connectors.postgres.postgres_connector import PostgreSQLConnector
+from infrastructure.adapters.out.connectors.sqlserver.sqlserver_connector import SQLServerConnector
+from infrastructure.adapters.out.connectors.mysql.mysql_connector import MySQLConnector
+from infrastructure.adapters.out.connectors.mongodb.mongodb_connector import MongoDBConnector
+from infrastructure.adapters.out.connectors.redis.redis_connector import RedisConnector
+from infrastructure.adapters.out.connectors.cassandra.cassandra_connector import CassandraConnector
+from infrastructure.adapters.out.persistence.repositories.db_repository import DbRepository
+from infrastructure.adapters.out.persistence.utils.db_credentials_helper import get_db_credentials
+from application.services.performance_service import PerformanceService
+from shared.performance_data import clear_performance_data
+
+CONNECTOR_MAP = {
+    "PostgreSQL": PostgreSQLConnector,
+    "SQLServer": SQLServerConnector,
+    "MySQL": MySQLConnector,
+    "MongoDB": MongoDBConnector,
+    "Redis": RedisConnector,
+    "Cassandra": CassandraConnector,
+}
+
+def multi_spaces_tab_view(defaults: dict):
+    st.header("Multi-Spaces")
+    st.write("Configure las credenciales para cada base de datos y ejecute las pruebas simultáneamente.")
+
+    creds = {}
+    for db_type, def_vals in defaults.items():
+        with st.expander(db_type, expanded=False):
+            host = st.text_input(f"Host {db_type}", value=def_vals.get("host", "localhost"), key=f"{db_type}_host_multi")
+            port = st.text_input(f"Puerto {db_type}", value=str(def_vals.get("port", "")), key=f"{db_type}_port_multi")
+            database = st.text_input(f"Base de Datos {db_type}", value=def_vals.get("database", ""), key=f"{db_type}_db_multi")
+            user = st.text_input(f"Usuario {db_type}", value=def_vals.get("user", ""), key=f"{db_type}_user_multi")
+            password = st.text_input(f"Contraseña {db_type}", type="password", value=def_vals.get("password", ""), key=f"{db_type}_pwd_multi")
+            creds[db_type] = get_db_credentials(db_type, host, port, database, user, password)
+
+    if st.button("Ejecutar Test en Todas"):
+        clear_performance_data()
+        test_operations = [
+            ("Búsqueda de cliente", "search_client"),
+            ("Búsqueda de producto", "search_product"),
+            ("Generación de factura", "generate_invoice"),
+            ("Consulta de factura", "query_invoice"),
+            ("Reporte de ventas", "sales_report"),
+        ]
+        for db_type, db_creds in creds.items():
+            connector_cls = CONNECTOR_MAP.get(db_type)
+            if not connector_cls:
+                st.warning(f"Conector no soportado para {db_type}")
+                continue
+            connector = connector_cls()
+            try:
+                connector.connect(**db_creds)
+                repo = DbRepository(connector_instance=connector)
+                repo.create_tables()
+                repo.create_stored_procedures()
+                repo.generate_test_data()
+                perf_service = PerformanceService(repo)
+                perf_service.run_performance_tests(db_type, test_operations)
+                st.success(f"Pruebas completadas en {db_type}")
+            except Exception as e:
+                st.error(f"Error en {db_type}: {e}")
+            finally:
+                try:
+                    connector.disconnect()
+                except Exception:
+                    pass
+        st.info("Pruebas finalizadas. Revise la pestaña 'Resultados y Estadísticas'.")

--- a/infrastructure/adapters/in_/ui/views/results_view.py
+++ b/infrastructure/adapters/in_/ui/views/results_view.py
@@ -3,28 +3,25 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from application.services.performance_service import PerformanceService
 
-def results_tab_view(performance_service: PerformanceService):
-    st.header("Resultados de Rendimiento")
 
+def render_performance_results(performance_service: PerformanceService) -> bool:
+    """Renderiza tablas y gráficos con los datos de rendimiento actuales."""
     performance_data_dict = performance_service.get_current_performance_data()
 
     if not performance_data_dict or not performance_data_dict['database']:
-        st.warning("No hay datos de rendimiento disponibles. Ejecute las pruebas primero desde la pestaña 'Ejecutar Pruebas de Rendimiento'.")
-        if st.button("Limpiar datos de rendimiento (si existen)"):
-            performance_service.clear_all_performance_data()
-            st.rerun()
-        return
+        st.warning(
+            "No hay datos de rendimiento disponibles. Ejecute las pruebas primero desde la pestaña 'Ejecutar Pruebas de Rendimiento'."
+        )
+        return False
 
     df = pd.DataFrame(performance_data_dict)
-    
     df_valid = df[df['time_ms'] >= 0]
 
     if df_valid.empty:
-        st.warning("Todos los resultados de las pruebas de rendimiento fueron erróneos o no hay datos válidos.")
-        if st.button("Limpiar datos de rendimiento"):
-            performance_service.clear_all_performance_data()
-            st.rerun()
-        return
+        st.warning(
+            "Todos los resultados de las pruebas de rendimiento fueron erróneos o no hay datos válidos."
+        )
+        return False
 
     st.subheader("Datos Crudos de Tiempos de Ejecución (ms)")
     st.dataframe(df)
@@ -34,39 +31,49 @@ def results_tab_view(performance_service: PerformanceService):
 
     st.subheader("Gráficos Comparativos (solo datos válidos)")
 
-    if not df_valid.empty:
-        try:
-            fig_bar, ax_bar = plt.subplots(figsize=(12, 7))
-            pivot_df = df_valid.pivot(index='database', columns='operation', values='time_ms')
-            pivot_df.plot(kind='bar', ax=ax_bar, width=0.8)
-            
-            ax_bar.set_title("Tiempo de Ejecución por Operación y Base de Datos", fontsize=16)
-            ax_bar.set_ylabel("Tiempo (ms)", fontsize=12)
-            ax_bar.set_xlabel("Base de Datos", fontsize=12)
-            ax_bar.legend(title="Operaciones", bbox_to_anchor=(1.05, 1), loc='upper left')
-            plt.xticks(rotation=0)
-            plt.tight_layout()
-            st.pyplot(fig_bar)
-        except Exception as e:
-            st.error(f"Error al generar gráfico de barras: {e}")
+    try:
+        fig_bar, ax_bar = plt.subplots(figsize=(12, 7))
+        pivot_df = df_valid.pivot(index='database', columns='operation', values='time_ms')
+        pivot_df.plot(kind='bar', ax=ax_bar, width=0.8)
 
-        try:
-            fig_line, ax_line = plt.subplots(figsize=(12, 7))
-            for db_name in df_valid['database'].unique():
-                db_data = df_valid[df_valid['database'] == db_name]
-                ax_line.plot(db_data['operation'], db_data['time_ms'], label=db_name, marker='o', linestyle='-')
-            
-            ax_line.set_title("Comparación de Rendimiento entre Bases de Datos", fontsize=16)
-            ax_line.set_ylabel("Tiempo (ms)", fontsize=12)
-            ax_line.set_xlabel("Operación", fontsize=12)
-            ax_line.legend(title="Base de Datos")
-            ax_line.grid(True, linestyle='--', alpha=0.7)
-            plt.xticks(rotation=45, ha="right")
-            plt.tight_layout()
-            st.pyplot(fig_line)
-        except Exception as e:
-            st.error(f"Error al generar gráfico de líneas: {e}")
-            
+        ax_bar.set_title("Tiempo de Ejecución por Operación y Base de Datos", fontsize=16)
+        ax_bar.set_ylabel("Tiempo (ms)", fontsize=12)
+        ax_bar.set_xlabel("Base de Datos", fontsize=12)
+        ax_bar.legend(title="Operaciones", bbox_to_anchor=(1.05, 1), loc='upper left')
+        plt.xticks(rotation=0)
+        plt.tight_layout()
+        st.pyplot(fig_bar)
+    except Exception as e:
+        st.error(f"Error al generar gráfico de barras: {e}")
+
+    try:
+        fig_line, ax_line = plt.subplots(figsize=(12, 7))
+        for db_name in df_valid['database'].unique():
+            db_data = df_valid[df_valid['database'] == db_name]
+            ax_line.plot(db_data['operation'], db_data['time_ms'], label=db_name, marker='o', linestyle='-')
+
+        ax_line.set_title("Comparación de Rendimiento entre Bases de Datos", fontsize=16)
+        ax_line.set_ylabel("Tiempo (ms)", fontsize=12)
+        ax_line.set_xlabel("Operación", fontsize=12)
+        ax_line.legend(title="Base de Datos")
+        ax_line.grid(True, linestyle='--', alpha=0.7)
+        plt.xticks(rotation=45, ha="right")
+        plt.tight_layout()
+        st.pyplot(fig_line)
+    except Exception as e:
+        st.error(f"Error al generar gráfico de líneas: {e}")
+
+    return True
+
+def results_tab_view(performance_service: PerformanceService):
+    st.header("Resultados de Rendimiento")
+
+    if not render_performance_results(performance_service):
+        if st.button("Limpiar datos de rendimiento (si existen)"):
+            performance_service.clear_all_performance_data()
+            st.rerun()
+        return
+
     if st.button("Limpiar Datos de Rendimiento Mostrados"):
         performance_service.clear_all_performance_data()
         st.rerun()

--- a/infrastructure/adapters/out/connectors/cassandra/cassandra_connector.py
+++ b/infrastructure/adapters/out/connectors/cassandra/cassandra_connector.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from cassandra.cluster import Cluster
 from cassandra.auth import PlainTextAuthProvider
+from cassandra.io.asyncioreactor import AsyncioConnection
 import pandas as pd
 from infrastructure.adapters.out.connectors.base_connector import BaseConnector
 
@@ -17,7 +18,12 @@ class CassandraConnector(BaseConnector):
 
     def connect(self, host, database, user, password, port):
         auth_provider = PlainTextAuthProvider(username=user, password=password)
-        self.cluster = Cluster([host], port=port, auth_provider=auth_provider)
+        self.cluster = Cluster(
+            [host],
+            port=port,
+            auth_provider=auth_provider,
+            connection_class=AsyncioConnection
+        )
         self.session = self.cluster.connect()
         self.session.execute(
             f"CREATE KEYSPACE IF NOT EXISTS {database} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': 1}}"


### PR DESCRIPTION
## Summary
- fix Cassandra connector for Python 3.12 by using `AsyncioConnection`
- add new **Multi-Spaces** tab that lets you set credentials for every DB and run tests across all of them

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68543ad780e883219927e2b3e10f897e